### PR TITLE
[LIBS LINKING] Fix missing CBatchedLogger Linker Issue on Compile

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -744,6 +744,7 @@ libscc_util_a_SOURCES = \
   util/threadnames.cpp \
   util/url.cpp \
   util/validation.cpp \
+  batchedlogger.cpp \
   $(BITCOIN_CORE_H)
 
 if GLIBC_BACK_COMPAT


### PR DESCRIPTION
Fixes make error

`CXX      leveldb/helpers/memenv/libmemenv_a-memenv.o
  AR       leveldb/libmemenv.a
make[3]: Entering directory '/root/StakeCubeCoin-memory-testing-001/src/secp256k1'
gcc -DHAVE_CONFIG_H -I. -I./src -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wcast-align=strict -fvisibility=hidden -g -O2 -c src/gen_context.c -o gen_context.o
gcc -O2  -std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef -Wno-overlength-strings -Wall -Wno-unused-function -Wextra -Wcast-align -Wcast-align=strict -fvisibility=hidden -g -O2  gen_context.o -o gen_context
./gen_context
  CC       src/libsecp256k1_la-secp256k1.lo
  CCLD     libsecp256k1.la
make[3]: Leaving directory '/root/StakeCubeCoin-memory-testing-001/src/secp256k1'
  CXXLD    sccd
Undefined symbols for architecture x86_64:
  "typeinfo for CBatchedLogger", referenced from:
      typeinfo for llmq::CDKGLogger in libscc_server.a(libscc_server_a-dkgsession.o)
  "CBatchedLogger::Flush()", referenced from:
      llmq::CDKGSession::SendContributions(llmq::CDKGPendingMessages&) in libscc_server.a(libscc_server_a-dkgsession.o)
      llmq::CDKGSession::VerifyAndComplain(llmq::CDKGPendingMessages&) in libscc_server.a(libscc_server_a-dkgsession.o)
      llmq::CDKGSession::SendComplaint(llmq::CDKGPendingMessages&) in libscc_server.a(libscc_server_a-dkgsession.o)
      llmq::CDKGSession::VerifyAndJustify(llmq::CDKGPendingMessages&) in libscc_server.a(libscc_server_a-dkgsession.o)
      llmq::CDKGSession::SendJustification(llmq::CDKGPendingMessages&, std::__1::set<uint256, std::__1::less<uint256>, std::__1::allocator<uint256> > const&) in libscc_server.a(libscc_server_a-dkgsession.o)
      llmq::CDKGSession::VerifyAndCommit(llmq::CDKGPendingMessages&) in libscc_server.a(libscc_server_a-dkgsession.o)
      llmq::CDKGSession::SendCommitment(llmq::CDKGPendingMessages&) in libscc_server.a(libscc_server_a-dkgsession.o)
      ...
  "CBatchedLogger::CBatchedLogger(BCLog::LogFlags, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      llmq::CDKGLogger::CDKGLogger(llmq::CDKGSession const&, std::__1::basic_string_view<char, std::__1::char_traits<char> >) in libscc_server.a(libscc_server_a-dkgsession.o)
  "CBatchedLogger::~CBatchedLogger()", referenced from:
      llmq::CDKGSession::Init(CBlockIndex const*, std::__1::vector<std::__1::shared_ptr<CDeterministicMN const>, std::__1::allocator<std::__1::shared_ptr<CDeterministicMN const> > > const&, uint256 const&) in libscc_server.a(libscc_server_a-dkgsession.o)
      llmq::CDKGLogger::~CDKGLogger() in libscc_server.a(libscc_server_a-dkgsession.o)
      llmq::CDKGSession::Contribute(llmq::CDKGPendingMessages&) in libscc_server.a(libscc_server_a-dkgsession.o)
      llmq::CDKGSession::SendContributions(llmq::CDKGPendingMessages&) in libscc_server.a(libscc_server_a-dkgsession.o)
      llmq::CDKGSession::PreVerifyMessage(llmq::CDKGContribution const&, bool&) const in libscc_server.a(libscc_server_a-dkgsession.o)
      llmq::CDKGSession::ReceiveMessage(llmq::CDKGContribution const&, bool&) in libscc_server.a(libscc_server_a-dkgsession.o)
      llmq::CDKGSession::VerifyPendingContributions() in libscc_server.a(libscc_server_a-dkgsession.o)
      ...
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [Makefile:7591: sccd] Error 1
make[2]: Leaving directory '/root/StakeCubeCoin-memory-testing-001/src'
`